### PR TITLE
Fix long Select fields from overflowing

### DIFF
--- a/resources/sass/vendors/vue-select.scss
+++ b/resources/sass/vendors/vue-select.scss
@@ -1,5 +1,5 @@
 .v-select {
-	@apply rounded;
+	@apply rounded min-w-0;
 	position: relative;
 	font-family: inherit
 }
@@ -54,6 +54,10 @@
 	.vs--disabled & {
 		@apply bg-grey-20;
 	}
+}
+
+.vs__selected-options {
+    @apply min-w-0;
 }
 
 .v-select:not(.vs--unsearchable) .vs__selected-options {


### PR DESCRIPTION
By default, the flex wrappers around the select field will inherit their width from their content, allowing them to overflow the container when the value is really long.

![overflow](https://user-images.githubusercontent.com/2236267/96680603-a99b1800-132a-11eb-9880-e9443ec0a7af.png)

Setting a min-width of 0 allows them to shrink to the containing element.

![contained](https://user-images.githubusercontent.com/2236267/96680769-fd0d6600-132a-11eb-85ca-d4d81a425649.png)